### PR TITLE
Made all messages a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -704,6 +704,11 @@ setTimeout(() => { // load all db's into memory
         break;
       }
       default: {
+	if (msg.startsWith("/sendasbot")) {
+	  io.to(room).emit('botMessage', msg.substring(10));
+	  return;
+	  break;
+	}
         if (!filter.isProfane(msg.replace(String.fromCharCode(8203), ''))) { // checks if message doesn't contain rude words
           if (msg.length > 250) {
             io.to(socketIdd).emit('botMessage', 'Do not bypass the char limits!  This is a warning!');

--- a/index.js
+++ b/index.js
@@ -306,7 +306,8 @@ setTimeout(() => { // load all db's into memory
         user: object.sender
       }, (error, doc) => {
         if (doc.length == 0) return;
-        var safemsg = betterReplace(object.message, "", "​");
+	var msgString = object.message + "";
+        var safemsg = betterReplace(msgString, "", "​");
         var hashFromDb = doc[0].hashString;
         //bcrypt.compare(hashFromDb, object.hash).then(async function(result) {
         // console.log(result) // ROP
@@ -344,14 +345,14 @@ setTimeout(() => { // load all db's into memory
                         hashString: toHash
                       }
                       userDb.insert(userDoc, function(err, docc) { // insert the document to the database
-                        sendMessage(currentRoom, object.message, object.sender, [data], socket.id)
+                        sendMessage(currentRoom, msgString, object.sender, [data], socket.id)
                       })
                     });
                 } else {
                   var locateDoc = userDb.find({ // if the user does exist
                     user: object.sender // set the username to the sender's username
                   }, function(err, doc) {
-                    sendMessage(currentRoom, object.message, object.sender, doc, socket.id);
+                    sendMessage(currentRoom, msgString, object.sender, doc, socket.id);
                   });
                 }
               }


### PR DESCRIPTION
Made all messages a string, if they were a number, before running string prototype functions. If anyone runs the following code in DevTools, the entire server shuts down.
```js
socket.emit("chatMessage",{message: 0,sender: window.localStorage.getItem("userName"),hash: window.localStorage.getItem("userHash"),socket: socket.id});

```